### PR TITLE
Add manual workflow to deploy docker images to blockstack

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -33,7 +33,7 @@ jobs:
           file: ./devenv/sbtc/docker/Dockerfile
           # TODO: Set up docker publishing to use the tag name when publishing and to do
           # something else when triggered manually. $\{{ github.event.release.tag_name }}
-          tags: blockstack/sbtc:sbtc
+          tags: blockstack/sbtc:devenv-sbtc
           push: true
           platform: amd64
 
@@ -75,5 +75,5 @@ jobs:
           push: true
           # TODO: Set up docker publishing to use the tag name when publishing and to do
           # something else when triggered manually. $\{{ github.event.release.tag_name }}
-          tags: blockstack/sbtc:${{ matrix.service }}
+          tags: blockstack/sbtc:devenv-${{ matrix.service }}
           platform: amd64

--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -1,0 +1,79 @@
+
+name: Publish Docker image
+
+on:
+  push:
+    branches: build-docker-images
+  release:
+    types: [published]
+  # Allow workflow to be triggered manually.
+  workflow_dispatch:
+
+jobs:
+  push_sbtc_to_registry:
+    name: Push sBTC Docker Image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          # We use ubuntu-latest which implies amd64
+          context: "{{ defaultContext }}"
+          file: ./devenv/sbtc/docker/Dockerfile
+          # TODO: Set up docker publishing to use the tag name when publishing and to do
+          # something else when triggered manually. $\{{ github.event.release.tag_name }}
+          tags: blockstack/sbtc:sbtc
+          push: true
+          platform: amd64
+
+  push_services_to_registry:
+    strategy:
+      matrix:
+        service: [
+          electrs,
+          bitcoin,
+          miner,
+          sbtc-bridge-api,
+          sbtc-bridge-web,
+          stacks,
+          stacks-api,
+          stacks-explorer,
+        ]
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        if: ${{ matrix.service }} == sbtc
+        with:
+          # Note, this is a little hacky because it requires each service that we 
+          # have to use the same folder structure.
+          context: "{{ defaultContext }}:/devenv/${{ matrix.service }}/docker"
+          file: ./Dockerfile
+          push: true
+          # TODO: Set up docker publishing to use the tag name when publishing and to do
+          # something else when triggered manually. $\{{ github.event.release.tag_name }}
+          tags: blockstack/sbtc:${{ matrix.service }}
+          platform: amd64


### PR DESCRIPTION
## Summary of Changes

Add manual docker image publishing

## Testing

### Risks

Few risks. It could provide faulty images and make people believe their code is broken when it's just the images.

### How were these changes tested?

Tested on an x86 computer. Has issues with ARM64

### What future testing should occur?

Should find a way to generate arm64 images. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
