### PR TITLE
remove panic on unexpected number of Stacks statuses updated

### DIFF
--- a/romeo/src/state.rs
+++ b/romeo/src/state.rs
@@ -356,6 +356,7 @@ impl State {
 					);
 				} else {
 					debug!("Unexpected number of Stacks statuses updated");
+					return false;
 				}
 			}
 		}

--- a/romeo/src/state.rs
+++ b/romeo/src/state.rs
@@ -350,10 +350,13 @@ impl State {
 
 		if let Some(statuses_updated) = statuses_updated {
 			if statuses_updated != 1 {
-				panic!(
-					"Unexpected number of Stacks statuses updated: {}",
-					statuses_updated
-				);
+				if config.strict {
+					panic!(
+						"Unexpected number of Stacks statuses updated: {}",
+					);
+				} else {
+					debug!("Unexpected number of Stacks statuses updated");
+				}
 			}
 		}
 


### PR DESCRIPTION
just removes the panic when the server is restarted and it processes all the previous mints and burns
