### PR TITLE
[sBTC DR] chore: Remove deprecated @types/typescript dependency

### DIFF
--- a/romeo/asset-contract/package-lock.json
+++ b/romeo/asset-contract/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@hirosystems/clarinet-sdk": "^1.0.1",
         "@stacks/transactions": "^6.9.0",
-        "@types/typescript": "^2.0.0",
         "fast-check": "^3.13.1",
         "typescript": "^5.2.2",
         "vite": "^4.4.9",
@@ -472,15 +471,6 @@
       "version": "18.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
       "integrity": "sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w=="
-    },
-    "node_modules/@types/typescript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/typescript/-/typescript-2.0.0.tgz",
-      "integrity": "sha512-WMEWfMISiJ2QKyk5/dSdgL0ZwP//PZj0jmDU0hMh51FmLq4WIYzjlngsUQZXejQL+QtkXJUOGjb3G3UCvgZuSQ==",
-      "deprecated": "This is a stub types definition for TypeScript (https://github.com/Microsoft/TypeScript). TypeScript provides its own type definitions, so you don't need @types/typescript installed!",
-      "dependencies": {
-        "typescript": "*"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "0.34.6",

--- a/romeo/asset-contract/package.json
+++ b/romeo/asset-contract/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@hirosystems/clarinet-sdk": "^1.0.1",
     "@stacks/transactions": "^6.9.0",
-    "@types/typescript": "^2.0.0",
     "fast-check": "^3.13.1",
     "typescript": "^5.2.2",
     "vite": "^4.4.9",


### PR DESCRIPTION
### Summary:
Removed the deprecated `@types/typescript` dependency from `romeo/asset-contract/package.json` as TypeScript provides its own type definitions. This addresses the npm warning seen during installation.

### Changes:
- Removed `@types/typescript` from `romeo/asset-contract/package.json`.

### Benefits:
- Simplifies the package dependencies.
- Eliminates the npm warning related to the deprecated package.

## Testing

Once you `cd` into `romeo/asset-contract` directory, run `npm install` and there should be no warnings.

### Risks

<!--
Please list, loosely, the risks that are associated with this PR. This can be very short. Even a documentation update would have the risk that the added information misleads a user to do or think XYZ.
-->

### How were these changes tested?

By `cd`ing into `romeo/asset-contract` directory and running `npm install` and then `npm test`.

### What future testing should occur?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

(Let me know if there's a style guideline of this project that I can follow, and any changes to the documentation that I should make. There are no dependent changes in downstream modules.)