### PR TITLE
Resolve Issue 417 - Missing node-gyph-build 

### DIFF
--- a/devenv/stacks-explorer/docker/Dockerfile
+++ b/devenv/stacks-explorer/docker/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /app
 RUN apk add --no-cache git python3 make g++
 RUN git clone ${GIT_URI} -b ${GIT_BRANCH} .
 RUN npm install -g pnpm
+RUN npm install -g node-gyp-build
 RUN pnpm i
 RUN pnpm build
 


### PR DESCRIPTION
Resolves #417 

## Summary of Changes

Added
```
RUN npm install -g node-gyp-build
```
to `sbtc/devenv/stacks-explorer/docker/Dockerfile`

## Testing
`devenv/build.sh` ran successfully


### Risks
NA

### How were these changes tested?
`devenv/build.sh` ran successfully


### What future testing should occur?
NA

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
